### PR TITLE
Generate vless and ssh openvpn account details

### DIFF
--- a/FORMATTED-DISPLAY-README.md
+++ b/FORMATTED-DISPLAY-README.md
@@ -1,0 +1,157 @@
+# Formatted Account Display
+
+## Overview
+This feature provides beautifully formatted account displays for VPN services, similar to the examples you provided. The formatted display shows account information in a clean, organized manner with proper borders and colors.
+
+## Features
+
+### 1. VLESS Account Display
+- Shows account details with proper formatting
+- Displays all connection links (TLS, non-TLS, gRPC)
+- Includes domain, ports, and configuration details
+- Uses the exact format you specified
+
+### 2. SSH/OpenVPN Account Display
+- Shows SSH account information with diamond borders
+- Displays connection details and payloads
+- Includes all port configurations
+- Matches your example format exactly
+
+### 3. VMess Account Display
+- Formatted VMess account information
+- Base64 encoded connection links
+- All protocol details included
+
+### 4. Trojan Account Display
+- Trojan account formatting
+- Connection links for all protocols
+- Complete configuration details
+
+## Usage
+
+### Option 1: Standalone Script
+```bash
+./account-display.sh
+```
+
+### Option 2: Integrated in Main Script
+```bash
+./vpn-installer.sh
+# Then select option 16: Formatted Display
+```
+
+### Option 3: Test with Sample Data
+```bash
+./test-formatted-display.sh
+# This creates sample accounts for testing
+```
+
+## Menu Options
+
+When you run the formatted display, you'll see:
+
+1. **Display VLESS Account** - Show formatted VLESS account information
+2. **Display SSH/OpenVPN Account** - Show formatted SSH account information
+3. **Display VMess Account** - Show formatted VMess account information
+4. **Display Trojan Account** - Show formatted Trojan account information
+5. **List All Accounts** - Show all active accounts in a list format
+
+## Account Creation Integration
+
+When you create new accounts using the main script:
+- After creating a VLESS account, it will automatically show the formatted display
+- After creating an SSH account, it will automatically show the formatted display
+- The formatted display appears after the regular account creation output
+
+## File Structure
+
+The script reads account information from:
+- `/etc/xray/vless_account` - VLESS accounts
+- `/etc/ssh/ssh_account` - SSH accounts
+- `/etc/xray/vmess_account` - VMess accounts
+- `/etc/xray/trojan_account` - Trojan accounts
+- `/etc/vpn_domain` - Domain configuration
+
+## Format Examples
+
+### VLESS Account Format
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+        VLESS Account
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Remarks        : ocean
+Domain         : yourdomain.com
+Wildcard       : (bug.com).yourdomain.com
+Port TLS       : 443
+Port none TLS  : 80
+Port gRPC      : 443
+id             : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+Encryption     : none
+Network        : ws
+Path           : /vless
+Path gRPC      : vless-grpc
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Link TLS       : vless://uuid@yourdomain.com:443?path=/vless&security=tls&encryption=none&type=ws#ocean
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Link none TLS  : vless://uuid@yourdomain.com:80?path=/vless&encryption=none&type=ws#ocean
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Link gRPC      : vless://uuid@yourdomain.com:443?mode=gun&security=tls&encryption=none&type=grpc&serviceName=vless-grpc&sni=bug.com#ocean
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Expired On     : 2025-08-01
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### SSH/OpenVPN Account Format
+```
+━━━━━━━━━━━━━━━━━◇
+     SSH OPENVPN
+◇━━━━━━━━━━━━━━━━━◇
+Remark      : bumiayu
+Username    : bumiayu
+Password    : vpn
+Limit IP    : 1 Device
+Domain      : yourdomain.com
+ISP         : Rumahweb Indonesia
+OpenSSH     : 22, 80, 443
+SSH WS      : 80, 8080, 8880, 2082
+SSL/TLS     : 443
+OVPN UDP    : 2200
+◇━━━━━━━━━━━━━━━━━◇
+Port 80     : yourdomain.com:80@bumiayu:vpn
+Port 443    : yourdomain.com:443@bumiayu:vpn
+Udp Custom  : yourdomain.com:1-65535@bumiayu:vpn
+OpenVpn     : https://yourdomain.com:81/
+Account     : https://yourdomain.com:81/ssh-bumiayu.txt
+◇━━━━━━━━━━━━━━━━━◇
+Payload WS  : GET / HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]
+◇━━━━━━━━━━━━━━━━━◇
+Payload TLS : GET wss://yourdomain.com/ HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]
+◇━━━━━━━━━━━━━━━━━◇
+Payload ENCD: HEAD / HTTP/1.1[crlf]Host: Masukan_Bug[crlf][crlf]PATCH / HTTP/1.1[crlf]Host: [host][crlf]Upgrade: websocket[crlf][crlf][split]HTTP/ 1[crlf][crlf]
+◇━━━━━━━━━━━━━━━━━◇
+Expiry in  : 2025-01-01
+◇━━━━━━━━━━━━━━━━━◇
+```
+
+## Requirements
+
+- Bash shell
+- Color support in terminal
+- Account files must exist in the correct format
+- Domain configuration file
+
+## Notes
+
+- The script automatically detects your domain from `/etc/vpn_domain` or uses your IP address
+- All links are generated with the correct domain and account information
+- The format matches exactly what you specified in your examples
+- Port 80 is configured to work with Cloudflare as requested
+- The display is optimized for readability and professional appearance
+
+## Troubleshooting
+
+If you encounter issues:
+1. Make sure account files exist and have the correct format
+2. Check that the domain file exists
+3. Ensure you have proper permissions to read the account files
+4. Verify that the account format follows: `### username expdate uuid/password`

--- a/account-display.sh
+++ b/account-display.sh
@@ -1,0 +1,390 @@
+#!/bin/bash
+# ===================================
+#  Account Display Formatter
+# ===================================
+# Displays VPN accounts in formatted style
+# ===================================
+
+# Colors
+GREEN="\e[32m"
+RED="\e[31m"
+YELLOW="\e[33m"
+BLUE="\e[34m"
+CYAN="\e[36m"
+WHITE="\e[37m"
+NC="\e[0m"
+
+# Get domain
+DOMAIN=$(cat /etc/vpn_domain 2>/dev/null || curl -s ifconfig.me 2>/dev/null || echo "yourdomain.com")
+
+# Function to display VLESS account
+display_vless_account() {
+    local user=$1
+    local uuid=$2
+    local expdate=$3
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}        VLESS Account${NC}"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Remarks        :${NC} $user"
+    echo -e "${CYAN}Domain         :${NC} $DOMAIN"
+    echo -e "${CYAN}Wildcard       :${NC} (bug.com).$DOMAIN"
+    echo -e "${CYAN}Port TLS       :${NC} 443"
+    echo -e "${CYAN}Port none TLS  :${NC} 80"
+    echo -e "${CYAN}Port gRPC      :${NC} 443"
+    echo -e "${CYAN}id             :${NC} $uuid"
+    echo -e "${CYAN}Encryption     :${NC} none"
+    echo -e "${CYAN}Network        :${NC} ws"
+    echo -e "${CYAN}Path           :${NC} /vless"
+    echo -e "${CYAN}Path gRPC      :${NC} vless-grpc"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link TLS       :${NC} vless://$uuid@$DOMAIN:443?path=/vless&security=tls&encryption=none&type=ws#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link none TLS  :${NC} vless://$uuid@$DOMAIN:80?path=/vless&encryption=none&type=ws#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link gRPC      :${NC} vless://$uuid@$DOMAIN:443?mode=gun&security=tls&encryption=none&type=grpc&serviceName=vless-grpc&sni=bug.com#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Expired On     :${NC} $expdate"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Press any key to back on VLESS${NC}"
+    read -n1 -r
+}
+
+# Function to display SSH/OpenVPN account
+display_ssh_account() {
+    local user=$1
+    local pass=$2
+    local expdate=$3
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${WHITE}     SSH OPENVPN${NC}"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Remark      :${NC} $user"
+    echo -e "${CYAN}Username    :${NC} $user"
+    echo -e "${CYAN}Password    :${NC} $pass"
+    echo -e "${CYAN}Limit IP    :${NC} 1 Device"
+    echo -e "${CYAN}Domain      :${NC} $DOMAIN"
+    echo -e "${CYAN}ISP         :${NC} Rumahweb Indonesia"
+    echo -e "${CYAN}OpenSSH     :${NC} 22, 80, 443"
+    echo -e "${CYAN}SSH WS      :${NC} 80, 8080, 8880, 2082"
+    echo -e "${CYAN}SSL/TLS     :${NC} 443"
+    echo -e "${CYAN}OVPN UDP    :${NC} 2200"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Port 80     :${NC} $DOMAIN:80@$user:$pass"
+    echo -e "${CYAN}Port 443    :${NC} $DOMAIN:443@$user:$pass"
+    echo -e "${CYAN}Udp Custom  :${NC} $DOMAIN:1-65535@$user:$pass"
+    echo -e "${CYAN}OpenVpn     :${NC} https://$DOMAIN:81/"
+    echo -e "${CYAN}Account     :${NC} https://$DOMAIN:81/ssh-$user.txt"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload WS  :${NC} GET / HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload TLS :${NC} GET wss://$DOMAIN/ HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload ENCD:${NC} HEAD / HTTP/1.1[crlf]Host: Masukan_Bug[crlf][crlf]PATCH / HTTP/1.1[crlf]Host: [host][crlf]Upgrade: websocket[crlf][crlf][split]HTTP/ 1[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Expiry in  :${NC} $expdate"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${YELLOW}Press any key to continue...${NC}"
+    read -n1 -r
+}
+
+# Function to display VMess account
+display_vmess_account() {
+    local user=$1
+    local uuid=$2
+    local expdate=$3
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}        VMess Account${NC}"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Remarks        :${NC} $user"
+    echo -e "${CYAN}Domain         :${NC} $DOMAIN"
+    echo -e "${CYAN}Wildcard       :${NC} (bug.com).$DOMAIN"
+    echo -e "${CYAN}Port TLS       :${NC} 443"
+    echo -e "${CYAN}Port none TLS  :${NC} 80"
+    echo -e "${CYAN}Port gRPC      :${NC} 443"
+    echo -e "${CYAN}id             :${NC} $uuid"
+    echo -e "${CYAN}AlterId        :${NC} 0"
+    echo -e "${CYAN}Security       :${NC} auto"
+    echo -e "${CYAN}Network        :${NC} ws"
+    echo -e "${CYAN}Path           :${NC} /vmess"
+    echo -e "${CYAN}Path gRPC      :${NC} vmess-grpc"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link TLS       :${NC} vmess://$(echo "{\"v\":\"2\",\"ps\":\"$user-CF443\",\"add\":\"$DOMAIN\",\"port\":\"443\",\"id\":\"$uuid\",\"aid\":\"0\",\"net\":\"ws\",\"type\":\"none\",\"host\":\"$DOMAIN\",\"path\":\"/vmess\",\"tls\":\"tls\"}" | base64 -w 0)"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link none TLS  :${NC} vmess://$(echo "{\"v\":\"2\",\"ps\":\"$user-CF80\",\"add\":\"$DOMAIN\",\"port\":\"80\",\"id\":\"$uuid\",\"aid\":\"0\",\"net\":\"ws\",\"type\":\"none\",\"host\":\"$DOMAIN\",\"path\":\"/vmess\",\"tls\":\"none\"}" | base64 -w 0)"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link gRPC      :${NC} vmess://$(echo "{\"v\":\"2\",\"ps\":\"$user-CF443\",\"add\":\"$DOMAIN\",\"port\":\"443\",\"id\":\"$uuid\",\"aid\":\"0\",\"net\":\"grpc\",\"type\":\"gun\",\"host\":\"$DOMAIN\",\"path\":\"vmess-grpc\",\"tls\":\"tls\"}" | base64 -w 0)"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Expired On     :${NC} $expdate"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Press any key to back on VMess${NC}"
+    read -n1 -r
+}
+
+# Function to display Trojan account
+display_trojan_account() {
+    local user=$1
+    local pass=$2
+    local expdate=$3
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}       Trojan Account${NC}"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Remarks        :${NC} $user"
+    echo -e "${CYAN}Domain         :${NC} $DOMAIN"
+    echo -e "${CYAN}Wildcard       :${NC} (bug.com).$DOMAIN"
+    echo -e "${CYAN}Port TLS       :${NC} 443"
+    echo -e "${CYAN}Port none TLS  :${NC} 80"
+    echo -e "${CYAN}Port gRPC      :${NC} 443"
+    echo -e "${CYAN}Password       :${NC} $pass"
+    echo -e "${CYAN}Network        :${NC} ws"
+    echo -e "${CYAN}Path           :${NC} /trojan"
+    echo -e "${CYAN}Path gRPC      :${NC} trojan-grpc"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link TLS       :${NC} trojan://$pass@$DOMAIN:443?type=ws&security=tls&host=$DOMAIN&path=%2Ftrojan#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link none TLS  :${NC} trojan://$pass@$DOMAIN:80?type=ws&security=none&host=$DOMAIN&path=%2Ftrojan#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link gRPC      :${NC} trojan://$pass@$DOMAIN:443?type=grpc&security=tls&host=$DOMAIN&serviceName=trojan-grpc#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Expired On     :${NC} $expdate"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Press any key to back on Trojan${NC}"
+    read -n1 -r
+}
+
+# Main menu
+main_menu() {
+    clear
+    echo -e "${BLUE}===================================${NC}"
+    echo -e "${BLUE}     Account Display Formatter${NC}"
+    echo -e "${BLUE}===================================${NC}"
+    echo ""
+    echo -e "${CYAN}[1]${NC} Display VLESS Account"
+    echo -e "${CYAN}[2]${NC} Display SSH/OpenVPN Account"
+    echo -e "${CYAN}[3]${NC} Display VMess Account"
+    echo -e "${CYAN}[4]${NC} Display Trojan Account"
+    echo -e "${CYAN}[5]${NC} List All Accounts"
+    echo -e "${CYAN}[0]${NC} Exit"
+    echo ""
+    read -rp "Choose menu: " menu_choice
+    
+    case $menu_choice in
+        1) vless_menu ;;
+        2) ssh_menu ;;
+        3) vmess_menu ;;
+        4) trojan_menu ;;
+        5) list_all_accounts ;;
+        0) exit 0 ;;
+        *) echo -e "${RED}Invalid choice!${NC}"; sleep 1; main_menu ;;
+    esac
+}
+
+# VLESS menu
+vless_menu() {
+    clear
+    echo -e "${BLUE}==== VLESS Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/xray/vless_account" ]; then
+        echo -e "${RED}No VLESS accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; main_menu; return
+    fi
+    
+    echo -e "${CYAN}Available VLESS accounts:${NC}"
+    echo ""
+    cat /etc/xray/vless_account | while IFS=' ' read -r mark user expdate uuid; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/xray/vless_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; vless_menu; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    uuid=$(echo "$account_line" | awk '{print $4}')
+    
+    display_vless_account "$username" "$uuid" "$expdate"
+    vless_menu
+}
+
+# SSH menu
+ssh_menu() {
+    clear
+    echo -e "${BLUE}==== SSH/OpenVPN Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/ssh/ssh_account" ]; then
+        echo -e "${RED}No SSH accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; main_menu; return
+    fi
+    
+    echo -e "${CYAN}Available SSH accounts:${NC}"
+    echo ""
+    cat /etc/ssh/ssh_account | while IFS=' ' read -r mark user expdate pass; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/ssh/ssh_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; ssh_menu; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    pass=$(echo "$account_line" | awk '{print $4}')
+    
+    display_ssh_account "$username" "$pass" "$expdate"
+    ssh_menu
+}
+
+# VMess menu
+vmess_menu() {
+    clear
+    echo -e "${BLUE}==== VMess Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/xray/vmess_account" ]; then
+        echo -e "${RED}No VMess accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; main_menu; return
+    fi
+    
+    echo -e "${CYAN}Available VMess accounts:${NC}"
+    echo ""
+    cat /etc/xray/vmess_account | while IFS=' ' read -r mark user expdate uuid; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/xray/vmess_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; vmess_menu; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    uuid=$(echo "$account_line" | awk '{print $4}')
+    
+    display_vmess_account "$username" "$uuid" "$expdate"
+    vmess_menu
+}
+
+# Trojan menu
+trojan_menu() {
+    clear
+    echo -e "${BLUE}==== Trojan Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/xray/trojan_account" ]; then
+        echo -e "${RED}No Trojan accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; main_menu; return
+    fi
+    
+    echo -e "${CYAN}Available Trojan accounts:${NC}"
+    echo ""
+    cat /etc/xray/trojan_account | while IFS=' ' read -r mark user expdate pass; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/xray/trojan_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; trojan_menu; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    pass=$(echo "$account_line" | awk '{print $4}')
+    
+    display_trojan_account "$username" "$pass" "$expdate"
+    trojan_menu
+}
+
+# List all accounts
+list_all_accounts() {
+    clear
+    echo -e "${BLUE}==== All Active Accounts ====${NC}"
+    echo ""
+    
+    echo -e "${CYAN}SSH Accounts:${NC}"
+    if [ -f "/etc/ssh/ssh_account" ]; then
+        cat /etc/ssh/ssh_account | while IFS=' ' read -r mark user expdate pass; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No SSH accounts${NC}"
+    fi
+    echo ""
+    
+    echo -e "${CYAN}VLESS Accounts:${NC}"
+    if [ -f "/etc/xray/vless_account" ]; then
+        cat /etc/xray/vless_account | while IFS=' ' read -r mark user expdate uuid; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No VLESS accounts${NC}"
+    fi
+    echo ""
+    
+    echo -e "${CYAN}VMess Accounts:${NC}"
+    if [ -f "/etc/xray/vmess_account" ]; then
+        cat /etc/xray/vmess_account | while IFS=' ' read -r mark user expdate uuid; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No VMess accounts${NC}"
+    fi
+    echo ""
+    
+    echo -e "${CYAN}Trojan Accounts:${NC}"
+    if [ -f "/etc/xray/trojan_account" ]; then
+        cat /etc/xray/trojan_account | while IFS=' ' read -r mark user expdate pass; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No Trojan accounts${NC}"
+    fi
+    echo ""
+    
+    read -n1 -r -p "Press any key..."; main_menu
+}
+
+# Start the script
+main_menu

--- a/test-formatted-display.sh
+++ b/test-formatted-display.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# ===================================
+#  Test Formatted Account Display
+# ===================================
+# This script creates sample account files and demonstrates
+# the formatted display functionality
+# ===================================
+
+# Colors
+GREEN="\e[32m"
+RED="\e[31m"
+YELLOW="\e[33m"
+BLUE="\e[34m"
+CYAN="\e[36m"
+WHITE="\e[37m"
+NC="\e[0m"
+
+# Create sample account files
+echo "Creating sample account files..."
+
+# Create directories
+mkdir -p /etc/ssh /etc/xray
+
+# Sample VLESS account
+echo "### ocean 2025-08-01 xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" > /etc/xray/vless_account
+
+# Sample SSH account
+echo "### bumiayu 2025-01-01 vpn" > /etc/ssh/ssh_account
+
+# Sample VMess account
+echo "### testuser 2025-06-01 yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy" > /etc/xray/vmess_account
+
+# Sample Trojan account
+echo "### trojanuser 2025-07-01 trojanpass123" > /etc/xray/trojan_account
+
+# Sample domain
+echo "yourdomain.com" > /etc/vpn_domain
+
+echo -e "${GREEN}Sample account files created!${NC}"
+echo ""
+echo -e "${CYAN}Now you can test the formatted display:${NC}"
+echo -e "${YELLOW}1. Run: ./account-display.sh${NC}"
+echo -e "${YELLOW}2. Or run: ./vpn-installer.sh and select option 16${NC}"
+echo ""
+echo -e "${BLUE}Sample accounts created:${NC}"
+echo -e "  VLESS: ocean"
+echo -e "  SSH: bumiayu"
+echo -e "  VMess: testuser"
+echo -e "  Trojan: trojanuser"
+echo ""
+echo -e "${GREEN}Ready to test!${NC}"

--- a/vpn-installer.sh
+++ b/vpn-installer.sh
@@ -544,7 +544,8 @@ main_menu() {
     echo -e " [9] Show Accounts   [10] Auto Expired"
     echo -e " [11] Auto Renew     [12] System Info"
     echo -e " [13] Speedtest      [14] Backup Config"
-    echo -e " [15] Auto Reboot    [0] Exit"
+    echo -e " [15] Auto Reboot    [16] Formatted Display"
+    echo -e " [0] Exit"
     echo -e "${CYAN}===================================${NC}"
     read -rp "Select menu: " menu
     case $menu in
@@ -563,6 +564,7 @@ main_menu() {
         13) speed_test ;;
         14) backup_config ;;
         15) auto_reboot ;;
+        16) formatted_display ;;
         0) exit 0 ;;
         *) echo "Invalid!"; sleep 1; main_menu ;;
     esac
@@ -596,14 +598,52 @@ add_ssh_account() {
     useradd -e $(date -d "+$exp days" +%Y-%m-%d) -s /bin/false -M $user
     echo -e "$pass\n$pass" | passwd $user &>/dev/null
     expdate=$(chage -l $user | grep "Account expires" | awk -F": " '{print $2}')
-    echo "### $user $expdate" >> /etc/ssh/ssh_account
+    echo "### $user $expdate $pass" >> /etc/ssh/ssh_account
     echo "Akun SSH berhasil dibuat!"
     echo "Host/IP: $(curl -s ifconfig.me)"
     echo "Username: $user"
     echo "Password: $pass"
     echo "Port: 22, 443 (Dropbear/OpenSSH)"
     echo "Expired: $expdate"
-    read -n1 -r -p "Press any key..."; manage_ssh
+    
+    echo ""
+    echo -e "${YELLOW}Press any key to see formatted display...${NC}"
+    read -n1 -r
+    
+    # Show formatted display
+    domain=$(cat /etc/vpn_domain 2>/dev/null || curl -s ifconfig.me 2>/dev/null || echo "yourdomain.com")
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${WHITE}     SSH OPENVPN${NC}"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Remark      :${NC} $user"
+    echo -e "${CYAN}Username    :${NC} $user"
+    echo -e "${CYAN}Password    :${NC} $pass"
+    echo -e "${CYAN}Limit IP    :${NC} 1 Device"
+    echo -e "${CYAN}Domain      :${NC} $domain"
+    echo -e "${CYAN}ISP         :${NC} Rumahweb Indonesia"
+    echo -e "${CYAN}OpenSSH     :${NC} 22, 80, 443"
+    echo -e "${CYAN}SSH WS      :${NC} 80, 8080, 8880, 2082"
+    echo -e "${CYAN}SSL/TLS     :${NC} 443"
+    echo -e "${CYAN}OVPN UDP    :${NC} 2200"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Port 80     :${NC} $domain:80@$user:$pass"
+    echo -e "${CYAN}Port 443    :${NC} $domain:443@$user:$pass"
+    echo -e "${CYAN}Udp Custom  :${NC} $domain:1-65535@$user:$pass"
+    echo -e "${CYAN}OpenVpn     :${NC} https://$domain:81/"
+    echo -e "${CYAN}Account     :${NC} https://$domain:81/ssh-$user.txt"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload WS  :${NC} GET / HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload TLS :${NC} GET wss://$domain/ HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload ENCD:${NC} HEAD / HTTP/1.1[crlf]Host: Masukan_Bug[crlf][crlf]PATCH / HTTP/1.1[crlf]Host: [host][crlf]Upgrade: websocket[crlf][crlf][split]HTTP/ 1[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Expiry in  :${NC} $expdate"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${YELLOW}Press any key to continue...${NC}"
+    read -n1 -r
+    manage_ssh
 }
 
 del_ssh_account() {
@@ -674,7 +714,38 @@ add_vless_account() {
     vless_link_2087="vless://$uuid@$domain:2087?encryption=none&security=none&type=ws&host=$domain&path=%2Fvless#${user}-DIR2087"
     echo "Port 2087 (Direct): $vless_link_2087"
     
-    read -n1 -r -p "Press any key..."; manage_vless
+    echo ""
+    echo -e "${YELLOW}Press any key to see formatted display...${NC}"
+    read -n1 -r
+    
+    # Show formatted display
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}        VLESS Account${NC}"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Remarks        :${NC} $user"
+    echo -e "${CYAN}Domain         :${NC} $domain"
+    echo -e "${CYAN}Wildcard       :${NC} (bug.com).$domain"
+    echo -e "${CYAN}Port TLS       :${NC} 443"
+    echo -e "${CYAN}Port none TLS  :${NC} 80"
+    echo -e "${CYAN}Port gRPC      :${NC} 443"
+    echo -e "${CYAN}id             :${NC} $uuid"
+    echo -e "${CYAN}Encryption     :${NC} none"
+    echo -e "${CYAN}Network        :${NC} ws"
+    echo -e "${CYAN}Path           :${NC} /vless"
+    echo -e "${CYAN}Path gRPC      :${NC} vless-grpc"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link TLS       :${NC} vless://$uuid@$domain:443?path=/vless&security=tls&encryption=none&type=ws#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link none TLS  :${NC} vless://$uuid@$domain:80?path=/vless&encryption=none&type=ws#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link gRPC      :${NC} vless://$uuid@$domain:443?mode=gun&security=tls&encryption=none&type=grpc&serviceName=vless-grpc&sni=bug.com#$user"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Expired On     :${NC} $expdate"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Press any key to back on VLESS${NC}"
+    read -n1 -r
+    manage_vless
 }
 
 del_vless_account() {
@@ -1208,6 +1279,343 @@ if [ ! -f /etc/xray/config.json ]; then
 }
 EOF
 fi
+
+# Function to display formatted accounts
+formatted_display() {
+    clear
+    echo -e "${BLUE}===================================${NC}"
+    echo -e "${BLUE}     Formatted Account Display${NC}"
+    echo -e "${BLUE}===================================${NC}"
+    echo ""
+    echo -e "${CYAN}[1]${NC} Display VLESS Account"
+    echo -e "${CYAN}[2]${NC} Display SSH/OpenVPN Account"
+    echo -e "${CYAN}[3]${NC} Display VMess Account"
+    echo -e "${CYAN}[4]${NC} Display Trojan Account"
+    echo -e "${CYAN}[5]${NC} List All Accounts"
+    echo -e "${CYAN}[0]${NC} Back to Main Menu"
+    echo ""
+    read -rp "Choose menu: " display_choice
+    
+    case $display_choice in
+        1) display_vless_formatted ;;
+        2) display_ssh_formatted ;;
+        3) display_vmess_formatted ;;
+        4) display_trojan_formatted ;;
+        5) list_all_formatted ;;
+        0) main_menu ;;
+        *) echo -e "${RED}Invalid choice!${NC}"; sleep 1; formatted_display ;;
+    esac
+}
+
+# Function to display VLESS account in formatted style
+display_vless_formatted() {
+    clear
+    echo -e "${BLUE}==== VLESS Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/xray/vless_account" ]; then
+        echo -e "${RED}No VLESS accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; formatted_display; return
+    fi
+    
+    echo -e "${CYAN}Available VLESS accounts:${NC}"
+    echo ""
+    cat /etc/xray/vless_account | while IFS=' ' read -r mark user expdate uuid; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/xray/vless_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; display_vless_formatted; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    uuid=$(echo "$account_line" | awk '{print $4}')
+    domain=$(cat /etc/vpn_domain 2>/dev/null || curl -s ifconfig.me 2>/dev/null || echo "yourdomain.com")
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}        VLESS Account${NC}"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Remarks        :${NC} $username"
+    echo -e "${CYAN}Domain         :${NC} $domain"
+    echo -e "${CYAN}Wildcard       :${NC} (bug.com).$domain"
+    echo -e "${CYAN}Port TLS       :${NC} 443"
+    echo -e "${CYAN}Port none TLS  :${NC} 80"
+    echo -e "${CYAN}Port gRPC      :${NC} 443"
+    echo -e "${CYAN}id             :${NC} $uuid"
+    echo -e "${CYAN}Encryption     :${NC} none"
+    echo -e "${CYAN}Network        :${NC} ws"
+    echo -e "${CYAN}Path           :${NC} /vless"
+    echo -e "${CYAN}Path gRPC      :${NC} vless-grpc"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link TLS       :${NC} vless://$uuid@$domain:443?path=/vless&security=tls&encryption=none&type=ws#$username"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link none TLS  :${NC} vless://$uuid@$domain:80?path=/vless&encryption=none&type=ws#$username"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link gRPC      :${NC} vless://$uuid@$domain:443?mode=gun&security=tls&encryption=none&type=grpc&serviceName=vless-grpc&sni=bug.com#$username"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Expired On     :${NC} $expdate"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Press any key to back on VLESS${NC}"
+    read -n1 -r
+    display_vless_formatted
+}
+
+# Function to display SSH account in formatted style
+display_ssh_formatted() {
+    clear
+    echo -e "${BLUE}==== SSH/OpenVPN Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/ssh/ssh_account" ]; then
+        echo -e "${RED}No SSH accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; formatted_display; return
+    fi
+    
+    echo -e "${CYAN}Available SSH accounts:${NC}"
+    echo ""
+    cat /etc/ssh/ssh_account | while IFS=' ' read -r mark user expdate pass; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/ssh/ssh_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; display_ssh_formatted; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    pass=$(echo "$account_line" | awk '{print $4}')
+    domain=$(cat /etc/vpn_domain 2>/dev/null || curl -s ifconfig.me 2>/dev/null || echo "yourdomain.com")
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${WHITE}     SSH OPENVPN${NC}"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Remark      :${NC} $username"
+    echo -e "${CYAN}Username    :${NC} $username"
+    echo -e "${CYAN}Password    :${NC} $pass"
+    echo -e "${CYAN}Limit IP    :${NC} 1 Device"
+    echo -e "${CYAN}Domain      :${NC} $domain"
+    echo -e "${CYAN}ISP         :${NC} Rumahweb Indonesia"
+    echo -e "${CYAN}OpenSSH     :${NC} 22, 80, 443"
+    echo -e "${CYAN}SSH WS      :${NC} 80, 8080, 8880, 2082"
+    echo -e "${CYAN}SSL/TLS     :${NC} 443"
+    echo -e "${CYAN}OVPN UDP    :${NC} 2200"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Port 80     :${NC} $domain:80@$username:$pass"
+    echo -e "${CYAN}Port 443    :${NC} $domain:443@$username:$pass"
+    echo -e "${CYAN}Udp Custom  :${NC} $domain:1-65535@$username:$pass"
+    echo -e "${CYAN}OpenVpn     :${NC} https://$domain:81/"
+    echo -e "${CYAN}Account     :${NC} https://$domain:81/ssh-$username.txt"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload WS  :${NC} GET / HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload TLS :${NC} GET wss://$domain/ HTTP/1.1[crlf]Host: [host][crlf]Connection: Upgrade[crlf]User-Agent: [ua][crlf]Upgrade: websocket[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Payload ENCD:${NC} HEAD / HTTP/1.1[crlf]Host: Masukan_Bug[crlf][crlf]PATCH / HTTP/1.1[crlf]Host: [host][crlf]Upgrade: websocket[crlf][crlf][split]HTTP/ 1[crlf][crlf]"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${CYAN}Expiry in  :${NC} $expdate"
+    echo -e "${WHITE}◇━━━━━━━━━━━━━━━━━◇${NC}"
+    echo -e "${YELLOW}Press any key to continue...${NC}"
+    read -n1 -r
+    display_ssh_formatted
+}
+
+# Function to display VMess account in formatted style
+display_vmess_formatted() {
+    clear
+    echo -e "${BLUE}==== VMess Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/xray/vmess_account" ]; then
+        echo -e "${RED}No VMess accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; formatted_display; return
+    fi
+    
+    echo -e "${CYAN}Available VMess accounts:${NC}"
+    echo ""
+    cat /etc/xray/vmess_account | while IFS=' ' read -r mark user expdate uuid; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/xray/vmess_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; display_vmess_formatted; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    uuid=$(echo "$account_line" | awk '{print $4}')
+    domain=$(cat /etc/vpn_domain 2>/dev/null || curl -s ifconfig.me 2>/dev/null || echo "yourdomain.com")
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}        VMess Account${NC}"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Remarks        :${NC} $username"
+    echo -e "${CYAN}Domain         :${NC} $domain"
+    echo -e "${CYAN}Wildcard       :${NC} (bug.com).$domain"
+    echo -e "${CYAN}Port TLS       :${NC} 443"
+    echo -e "${CYAN}Port none TLS  :${NC} 80"
+    echo -e "${CYAN}Port gRPC      :${NC} 443"
+    echo -e "${CYAN}id             :${NC} $uuid"
+    echo -e "${CYAN}AlterId        :${NC} 0"
+    echo -e "${CYAN}Security       :${NC} auto"
+    echo -e "${CYAN}Network        :${NC} ws"
+    echo -e "${CYAN}Path           :${NC} /vmess"
+    echo -e "${CYAN}Path gRPC      :${NC} vmess-grpc"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link TLS       :${NC} vmess://$(echo "{\"v\":\"2\",\"ps\":\"$username-CF443\",\"add\":\"$domain\",\"port\":\"443\",\"id\":\"$uuid\",\"aid\":\"0\",\"net\":\"ws\",\"type\":\"none\",\"host\":\"$domain\",\"path\":\"/vmess\",\"tls\":\"tls\"}" | base64 -w 0)"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link none TLS  :${NC} vmess://$(echo "{\"v\":\"2\",\"ps\":\"$username-CF80\",\"add\":\"$domain\",\"port\":\"80\",\"id\":\"$uuid\",\"aid\":\"0\",\"net\":\"ws\",\"type\":\"none\",\"host\":\"$domain\",\"path\":\"/vmess\",\"tls\":\"none\"}" | base64 -w 0)"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link gRPC      :${NC} vmess://$(echo "{\"v\":\"2\",\"ps\":\"$username-CF443\",\"add\":\"$domain\",\"port\":\"443\",\"id\":\"$uuid\",\"aid\":\"0\",\"net\":\"grpc\",\"type\":\"gun\",\"host\":\"$domain\",\"path\":\"vmess-grpc\",\"tls\":\"tls\"}" | base64 -w 0)"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Expired On     :${NC} $expdate"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Press any key to back on VMess${NC}"
+    read -n1 -r
+    display_vmess_formatted
+}
+
+# Function to display Trojan account in formatted style
+display_trojan_formatted() {
+    clear
+    echo -e "${BLUE}==== Trojan Account Display ====${NC}"
+    echo ""
+    
+    if [ ! -f "/etc/xray/trojan_account" ]; then
+        echo -e "${RED}No Trojan accounts found!${NC}"
+        read -n1 -r -p "Press any key..."; formatted_display; return
+    fi
+    
+    echo -e "${CYAN}Available Trojan accounts:${NC}"
+    echo ""
+    cat /etc/xray/trojan_account | while IFS=' ' read -r mark user expdate pass; do
+        if [ "$mark" = "###" ]; then
+            echo -e "${YELLOW}$user${NC} - Expires: $expdate"
+        fi
+    done
+    echo ""
+    read -rp "Enter username to display: " username
+    
+    # Get account info
+    account_line=$(grep "^### $username " /etc/xray/trojan_account)
+    if [ -z "$account_line" ]; then
+        echo -e "${RED}User not found!${NC}"
+        sleep 1; display_trojan_formatted; return
+    fi
+    
+    # Parse account info
+    expdate=$(echo "$account_line" | awk '{print $3}')
+    pass=$(echo "$account_line" | awk '{print $4}')
+    domain=$(cat /etc/vpn_domain 2>/dev/null || curl -s ifconfig.me 2>/dev/null || echo "yourdomain.com")
+    
+    clear
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${WHITE}       Trojan Account${NC}"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Remarks        :${NC} $username"
+    echo -e "${CYAN}Domain         :${NC} $domain"
+    echo -e "${CYAN}Wildcard       :${NC} (bug.com).$domain"
+    echo -e "${CYAN}Port TLS       :${NC} 443"
+    echo -e "${CYAN}Port none TLS  :${NC} 80"
+    echo -e "${CYAN}Port gRPC      :${NC} 443"
+    echo -e "${CYAN}Password       :${NC} $pass"
+    echo -e "${CYAN}Network        :${NC} ws"
+    echo -e "${CYAN}Path           :${NC} /trojan"
+    echo -e "${CYAN}Path gRPC      :${NC} trojan-grpc"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link TLS       :${NC} trojan://$pass@$domain:443?type=ws&security=tls&host=$domain&path=%2Ftrojan#$username"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link none TLS  :${NC} trojan://$pass@$domain:80?type=ws&security=none&host=$domain&path=%2Ftrojan#$username"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Link gRPC      :${NC} trojan://$pass@$domain:443?type=grpc&security=tls&host=$domain&serviceName=trojan-grpc#$username"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}Expired On     :${NC} $expdate"
+    echo -e "${WHITE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Press any key to back on Trojan${NC}"
+    read -n1 -r
+    display_trojan_formatted
+}
+
+# Function to list all accounts in formatted style
+list_all_formatted() {
+    clear
+    echo -e "${BLUE}==== All Active Accounts ====${NC}"
+    echo ""
+    
+    echo -e "${CYAN}SSH Accounts:${NC}"
+    if [ -f "/etc/ssh/ssh_account" ]; then
+        cat /etc/ssh/ssh_account | while IFS=' ' read -r mark user expdate pass; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No SSH accounts${NC}"
+    fi
+    echo ""
+    
+    echo -e "${CYAN}VLESS Accounts:${NC}"
+    if [ -f "/etc/xray/vless_account" ]; then
+        cat /etc/xray/vless_account | while IFS=' ' read -r mark user expdate uuid; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No VLESS accounts${NC}"
+    fi
+    echo ""
+    
+    echo -e "${CYAN}VMess Accounts:${NC}"
+    if [ -f "/etc/xray/vmess_account" ]; then
+        cat /etc/xray/vmess_account | while IFS=' ' read -r mark user expdate uuid; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No VMess accounts${NC}"
+    fi
+    echo ""
+    
+    echo -e "${CYAN}Trojan Accounts:${NC}"
+    if [ -f "/etc/xray/trojan_account" ]; then
+        cat /etc/xray/trojan_account | while IFS=' ' read -r mark user expdate pass; do
+            if [ "$mark" = "###" ]; then
+                echo -e "  ${YELLOW}$user${NC} - Expires: $expdate"
+            fi
+        done
+    else
+        echo -e "  ${RED}No Trojan accounts${NC}"
+    fi
+    echo ""
+    
+    read -n1 -r -p "Press any key..."; formatted_display
+}
 
 # Tampilkan menu utama
 main_menu


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds a formatted display for VPN account details (VLESS, SSH, VMess, Trojan) to improve readability and user experience.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This feature addresses the user's request for a "neat" and professional output, ensuring all relevant account information, including connection links and Cloudflare-compatible Port 80 details, is presented clearly after account creation and via a new menu option.

---
<a href="https://cursor.com/background-agent?bcId=bc-7793f78a-f178-4dbc-9b8e-e8cd5e5acf4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7793f78a-f178-4dbc-9b8e-e8cd5e5acf4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>